### PR TITLE
chore(dev-deps): bump `caniuse-lite` to 1.0.30001717

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7556,9 +7556,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001685",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001685.tgz",
-      "integrity": "sha512-e/kJN1EMyHQzgcMEEgoo+YTCO1NGCmIYHk5Qk8jT6AazWemS5QFKJ5ShCJlH3GZrNIdZofcNCEwZqbMjjKzmnA==",
+      "version": "1.0.30001717",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
+      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
       "dev": true,
       "funding": [
         {
@@ -7573,7 +7573,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",


### PR DESCRIPTION
This fixes the "Browserslist: browsers data (caniuse-lite) is 6 months old" warning during `npm run build`.